### PR TITLE
mmap error fix

### DIFF
--- a/src/mlx5_regex.c
+++ b/src/mlx5_regex.c
@@ -475,7 +475,7 @@ register_database(struct mlx5_regex_ctx *ctx, int engine_id)
 	/* Alloc data - here is a huge page allocation example */
 	ctx->db_ctx[engine_id].mem_desc.ptr = mmap(NULL, db_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS | MAP_POPULATE | MAP_HUGETLB, -1, 0);
 
-	if (!ctx->db_ctx[engine_id].mem_desc.ptr) {
+	if (ctx->db_ctx[engine_id].mem_desc.ptr == MAP_FAILED) {
 		syslog(LOG_NOTICE, "Allocation failed\n");
 		return -ENOMEM;
 	}

--- a/src/mlx5_regex.c
+++ b/src/mlx5_regex.c
@@ -476,7 +476,8 @@ register_database(struct mlx5_regex_ctx *ctx, int engine_id)
 	ctx->db_ctx[engine_id].mem_desc.ptr = mmap(NULL, db_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS | MAP_POPULATE | MAP_HUGETLB, -1, 0);
 
 	if (ctx->db_ctx[engine_id].mem_desc.ptr == MAP_FAILED) {
-		syslog(LOG_NOTICE, "Allocation failed\n");
+		syslog(LOG_ERR, "Failed to allocate %uMB from hugepages.\n", (db_size / (1024 * 1024)));
+		syslog(LOG_ERR, "Ensure hugepages are enabled.\n");
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
The call to mmap checked for an error by looking for a NULL pointer. This
is incorrect behaviour as mmap returns MAP_FAILED (-1) on failure.

Modify error checking accordingly.

Signed-off-by: John Hurley <jhurley@nvidia.com>