### PR TITLE
Configure huge pages before starting mlx-regex daemon

### DIFF
--- a/mlx-regex.service
+++ b/mlx-regex.service
@@ -6,6 +6,7 @@ Type=simple
 ExecStart=/usr/bin/mlx-regex
 RemainAfterExit=no
 ExecReload=/bin/kill -HUP $MAINPID
+ExecStartPre=/usr/sbin/setup_hugepages.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Update the mlx-regex.service file so that huge pages are configured before the mlx-regex daemon is started.

Signed-off-by: Gerry Gribbon <ggribbon@nvidia.com>