### PR TITLE
Use mlx-regex specific hugepage setup script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ add_subdirectory (src)
 # Directory with systemd unit files
 set (SYSTEMD_UNIT_DIR "/etc/systemd/system/")
 
+# Directory for mlx-regex huge pages script
+set (USR_SBIN_DIR "/usr/sbin")
+
 # Macro for installing configuration files
 function(install_conf src dest)
   if(NOT IS_ABSOLUTE "${src}")
@@ -70,3 +73,8 @@ endfunction(install_conf)
 
 # Install systemd unit files 
 install_conf (./mlx-regex.service ${SYSTEMD_UNIT_DIR})
+
+# Install hugepages script
+install(FILES contrib/mlx_regex_setup_hugepages.sh
+        DESTINATION ${USR_SBIN_DIR}
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)

--- a/contrib/mlx_regex_setup_hugepages.sh
+++ b/contrib/mlx_regex_setup_hugepages.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+# Dependency on package:
+#   libhugetlbfs-utils @ CentOS
+#   hugepages @ Ubuntu
+
+# Amount of hugepage memory needed by mlx-regex daemon
+min_hugemem=${MIN_HUGEMEM:-258M}
+
+# Units of memory for mlx-regex daemon
+case $(echo ${min_hugemem: -1}) in
+    M)
+        unit=m
+        ;;
+    G)
+        unit=g
+        ;;
+    K)
+        unit=k
+        ;;
+    *)
+        echo "[ERROR]: Unsupported unit format for hugepages!"
+        exit 1
+        ;;
+esac
+
+# Have any hugepages been configured yet
+hugetlb=$(grep Hugetlb /proc/meminfo | awk '{ print $2 }')
+
+# Check if existing hugepages can be used or if pool needs adjusted
+if [ $hugetlb -gt 0 ]; then
+    if [ $unit = "k" ]; then
+        required_size=${min_hugemem%?}
+    elif [ $unit = "m" ]; then
+	required_size=$((${min_hugemem%?} * 1024))
+    elif [ $unit = "g" ]; then
+	required_size=$((${min_hugemem%?} * 1024 * 1024))
+    fi
+
+    hugepagesize=$(grep Hugepagesize /proc/meminfo | awk '{ print $2 }')
+    hugePages_Free=$(grep HugePages_Free /proc/meminfo | awk '{ print $2 }')
+
+    huge_free_size=$((hugepagesize * hugePages_Free))
+
+    if [ $huge_free_size -ge $required_size ]; then
+        exit 0
+    fi
+fi
+
+# Adjust the pool size
+exec /usr/bin/hugeadm --pool-pages-min DEFAULT:+${min_hugemem}

--- a/mlx-regex.service
+++ b/mlx-regex.service
@@ -6,7 +6,7 @@ Type=simple
 ExecStart=/usr/bin/mlx-regex
 RemainAfterExit=no
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStartPre=/usr/sbin/setup_hugepages.sh
+ExecStartPre=/usr/sbin/mlx_regex_setup_hugepages.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/mlx_regex.spec
+++ b/mlx_regex.spec
@@ -32,6 +32,7 @@ make install DESTDIR=%{buildroot}
 %files
 /usr/bin/mlx-regex
 /etc/systemd/system/mlx-regex.service
+/usr/sbin/mlx_regex_setup_hugepages.sh
 
 %doc
 


### PR DESCRIPTION
Script checks there are sufficient huge pages available before starting the mlx-regex daemon. If there are not enough hugepages available, the script will attempt to increase the number.

Signed-off-by: Gerry Gribbon <ggribbon@nvidia.com>