### PR TITLE
Increase minimum number of hugepages for mlx-regex daemon

### DIFF
--- a/contrib/mlx_regex_setup_hugepages.sh
+++ b/contrib/mlx_regex_setup_hugepages.sh
@@ -4,7 +4,7 @@
 #   hugepages @ Ubuntu
 
 # Amount of hugepage memory needed by mlx-regex daemon
-min_hugemem=${MIN_HUGEMEM:-258M}
+min_hugemem=${MIN_HUGEMEM:-500M}
 
 # Units of memory for mlx-regex daemon
 case $(echo ${min_hugemem: -1}) in


### PR DESCRIPTION
Increase from 129 pages to 250 pages to ensure successful mlx-regex daemon startup.

Signed-off-by: Gerry Gribbon <ggribbon@nvidia.com>