### PR TITLE
Update copyright headers to Nvidia format

### DIFF
--- a/src/devx_prm.h
+++ b/src/devx_prm.h
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2021 Mellanox Technologies, Ltd. ALL RIGHTS RESERVED.
- *
- * This software product is a proprietary product of Mellanox Technologies Ltd.
- * (the "Company") and all right, title, and interest in and to the software
- * product, including all associated intellectual property rights, are and
- * shall remain exclusively with the Company.
- *
- * This software product is governed by the End User License Agreement
- * provided with the software product.
- *
- */
+* Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
+*
+* This software product is a proprietary product of NVIDIA CORPORATION &
+* AFFILIATES (the "Company") and all right, title, and interest in and to the
+* software product, including all associated intellectual property rights, are
+* and shall remain exclusively with the Company.
+*
+* This software product is governed by the End User License Agreement
+* provided with the software product.
+*
+*/
 
 #ifndef __DEVX_PRM_H__
 #define __DEVX_PRM_H__

--- a/src/mlx5_regex.c
+++ b/src/mlx5_regex.c
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2021 Mellanox Technologies, Ltd. ALL RIGHTS RESERVED.
- *
- * This software product is a proprietary product of Mellanox Technologies Ltd.
- * (the "Company") and all right, title, and interest in and to the software
- * product, including all associated intellectual property rights, are and
- * shall remain exclusively with the Company.
- *
- * This software product is governed by the End User License Agreement
- * provided with the software product.
- *
- */
+* Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
+*
+* This software product is a proprietary product of NVIDIA CORPORATION &
+* AFFILIATES (the "Company") and all right, title, and interest in and to the
+* software product, including all associated intellectual property rights, are
+* and shall remain exclusively with the Company.
+*
+* This software product is governed by the End User License Agreement
+* provided with the software product.
+*
+*/
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/mlx5_regex_ifc.h
+++ b/src/mlx5_regex_ifc.h
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2021 Mellanox Technologies, Ltd. ALL RIGHTS RESERVED.
- *
- * This software product is a proprietary product of Mellanox Technologies Ltd.
- * (the "Company") and all right, title, and interest in and to the software
- * product, including all associated intellectual property rights, are and
- * shall remain exclusively with the Company.
- *
- * This software product is governed by the End User License Agreement
- * provided with the software product.
- *
- */
+* Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
+*
+* This software product is a proprietary product of NVIDIA CORPORATION &
+* AFFILIATES (the "Company") and all right, title, and interest in and to the
+* software product, including all associated intellectual property rights, are
+* and shall remain exclusively with the Company.
+*
+* This software product is governed by the End User License Agreement
+* provided with the software product.
+*
+*/
 
 #ifndef MLX5_REGEX_IFC_H
 #define MLX5_REGEX_IFC_H


### PR DESCRIPTION
Replace copyright headers from Mellanox to Nvidia.

Signed-off-by: Gerry Gribbon <ggribbon@nvidia.com>