### PR TITLE
Update mlx-regex.service and mlx_regex.spec files

### DIFF
--- a/mlx-regex.service
+++ b/mlx-regex.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Regex daemon for BlueField 2
+Description=Regex daemon for BlueField
 After=openibd.service
 
 [Service]

--- a/mlx_regex.spec
+++ b/mlx_regex.spec
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Copyright (C) 2020 Mellanox Technologies. All Rights Reserved.
+# Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
 #
 
 Name:           mlx-regex
@@ -9,7 +9,7 @@ Release:        1%{?dist}
 License:        BSD
 URL:            mellanox.com
 Source0:        mlx-regex-1.2.tar.gz
-Summary:        Userspace regex service for Mellanox Bluefield 2
+Summary:        Userspace regex service for Nvidia Bluefield
 BuildRequires:  gcc, cmake, make
 BuildRequires:  systemd
 

--- a/src/devx_prm.h
+++ b/src/devx_prm.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
+* Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
 *
 * This software product is a proprietary product of NVIDIA CORPORATION &
 * AFFILIATES (the "Company") and all right, title, and interest in and to the

--- a/src/mlx5_regex.c
+++ b/src/mlx5_regex.c
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
+* Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
 *
 * This software product is a proprietary product of NVIDIA CORPORATION &
 * AFFILIATES (the "Company") and all right, title, and interest in and to the

--- a/src/mlx5_regex_ifc.h
+++ b/src/mlx5_regex_ifc.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
+* Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES, ALL RIGHTS RESERVED.
 *
 * This software product is a proprietary product of NVIDIA CORPORATION &
 * AFFILIATES (the "Company") and all right, title, and interest in and to the


### PR DESCRIPTION
- The mlx-regex daemon is now used on both Bluefield 2 and 3, Summary and Description entries changed to Bluefield only.

- Changed Mellanox to Nvidia in the mlx-regex.spec file

- Updated copyright headers for 2023

Signed-off-by: Gerry Gribbon <ggribbon@nvidia.com>