### PR TITLE
Update mlx-regex.service file for openibd restart

### DIFF
--- a/mlx-regex.service
+++ b/mlx-regex.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Regex daemon for BlueField
 After=openibd.service
+Requires=openibd.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
- mlx-regex daemon now requires openibd to be running before it starts
- if openibd is stopped via systemctl then mlx-regex daemon is stopped first
- if mlx-regex daemon is started then openibd is started if not running already.

Signed-off-by: Gerry Gribbon <ggribbon@nvidia.com>